### PR TITLE
Improving the CD display format

### DIFF
--- a/bot/events/onMessage.js
+++ b/bot/events/onMessage.js
@@ -5,6 +5,7 @@ const {adminID} = process.env.ADMIN_ID || require('../../auth.json');
 const {devID} = process.env.DEV_ID || require('../../auth.json');
 const fs = require('fs');
 const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const formated = require('../../commands/dependencies/_getFormatedCooldown');
 
 module.exports =
         {
@@ -77,7 +78,7 @@ module.exports =
 
             if (now < expirationTime) {
                 const timeLeft = (expirationTime - now) / 1000;
-                return message.reply(`Merci d'attendre encore ${timeLeft.toFixed(1)} secondes avant d'utiliser la commande \`${command.name}\` de nouveau.`);
+                return message.reply(`Merci d'attendre encore ${formated.getFormatedCooldown(timeLeft.toFixed(0))} secondes avant d'utiliser la commande \`${command.name}\` de nouveau.`);
             }
         }
 

--- a/commands/dependencies/_getFormatedCooldown.js
+++ b/commands/dependencies/_getFormatedCooldown.js
@@ -1,0 +1,16 @@
+module.exports = {
+    getFormatedCooldown: (timeInSeconds) => {
+        const hours = Math.floor(timeInSeconds / 3600);
+        timeInSeconds -= hours * 3600;
+        const minutes = Math.floor(timeInSeconds / 60);
+        const seconds = timeInSeconds - minutes * 60;
+
+        if(hours) {
+            return `${hours} h ${minutes} min ${seconds} sec`;
+        }else if(minutes) {
+            return `${minutes} min ${seconds} sec`;
+        }else {
+            return `${seconds} sec`;
+        }
+    }
+};


### PR DESCRIPTION
Now displays cooldowns by hours/minutes/seconds instead by seconds only.
🟢 Creating : dependencies/_getFormatedCooldown.js ;
🟠 Editing : events/onMessage.js.