### PR TITLE
Creating a function to format experience number

### DIFF
--- a/commands/dependencies/_getFormattedPlayerExperience.js
+++ b/commands/dependencies/_getFormattedPlayerExperience.js
@@ -1,0 +1,18 @@
+module.exports = {
+    // This function allows to replace traditional experience number by a "k" for the thousands
+    getFormattedExperience: experience => {
+        if(experience/1000 < 1){
+            return experience;
+        }
+        const arrayOfExp = Array.from(experience.toString());
+        let formattedExperience = '';
+        for(let i = 0; i < arrayOfExp.length - 2; i++){
+            if(i + 3 === arrayOfExp.length){
+                formattedExperience += 'k';
+                if (arrayOfExp[i] === '0') break;
+            }
+            formattedExperience += arrayOfExp[i];
+        }
+        return formattedExperience;
+    }
+};

--- a/commands/dependencies/_getPlayerSheet.js
+++ b/commands/dependencies/_getPlayerSheet.js
@@ -7,6 +7,7 @@ const {experienceFormat} = require('../../gameConfig');
 const playerLevelManager = require('./_getPlayerLevel');
 const expBarManager = require('./_getExperienceBar');
 const staminaManager = require('./_getPlayerStamina');
+const expManager = require('./_getFormattedPlayerExperience');
 
 module.exports = {
     getPlayerSheet: function(member) {
@@ -39,7 +40,7 @@ module.exports = {
                             .setDescription(`Fiche créée le ${frDate.getFrenchDate(player.createdAt)}`)
                             .addField("Inventaire", format.getFormattedPlayerInventory(player.playerInventory))
                             .addField("Matériaux", format.getFormattedPlayerInventory(player.playerMaterials, true))
-                            .addField("Expérience", `${player.playerExperience} ${experienceFormat}`, true)
+                            .addField("Expérience", `${expManager.getFormattedExperience(player.playerExperience)} ${experienceFormat}`, true)
                             .addField("Endurance", (playerStamina === playerMaxStamina ? `**${playerStamina}/${playerMaxStamina}**` : `${playerStamina}/${playerMaxStamina}`), true)
                             .addField(currency, player.playerPurse, true)
                             .addField('Rubis obtenus', `${player.playerRuby} :gem:`, true)


### PR DESCRIPTION
Experience numbers are now displayed with a "k" for the thousands (and ignore tens and units digits).

🟢 Creating : _getFormattedPlayerExperience.js ;
🟠 Editing : _getPlayerSheet.js.