### PR TITLE
Refactoring _addExperience (and dependencies)

### DIFF
--- a/commands/acceptChallenge.js
+++ b/commands/acceptChallenge.js
@@ -64,28 +64,27 @@ module.exports = {
                                     loser = initiatorPlayer;
                                 }
                                 const winExperience = expManager.addExperience(winner, challenge.amount, message);
-                                const loseExperience = expManager.addExperience(loser, Math.round(challenge.amount/3), message);
-
                                 winner.playerPurse += challenge.amount;
                                 winner.wonChallenge++;
-
-                                return message.channel.send(`<@${winner.playerId}> (\`+${winExperience}\` ${experienceFormat}) a remporté le défi face à <@${loser.playerId}> (\`+${loseExperience}\` ${experienceFormat}) ! Il dépouille son adversaire de \`${challengePrice} ${currency}\` !!`)
+                                winner.save()
                                     .then(() => {
-                                        winner.save()
+                                        const loseExperience = expManager.addExperience(loser, Math.round(challenge.amount/3), message);
+                                        loser.playerPurse -= challenge.amount;
+                                        loser.lostChallenge++;
+                                        loser.save()
                                             .then(() => {
-                                                loser.playerPurse -= challenge.amount;
-                                                loser.lostChallenge++;
-                                                loser.save()
+                                                challenge.delete()
                                                     .then(() => {
-                                                        challenge.delete()
+                                                        challengedPlayer.acceptedChallenge++;
+                                                        challengedPlayer.save()
                                                             .then(() => {
-                                                                challengedPlayer.acceptedChallenge++;
-                                                                challengedPlayer.save();
+                                                                return message.channel.send(`<@${winner.playerId}> (\`+${winExperience}\` ${experienceFormat}) a remporté le défi face à <@${loser.playerId}> (\`+${loseExperience}\` ${experienceFormat}) ! Il dépouille son adversaire de \`${challengePrice} ${currency}\` !!`);
                                                             });
                                                     });
                                             });
                                     });
-                            });
+
+                                });
                     });
             });
     }

--- a/commands/adventure.js
+++ b/commands/adventure.js
@@ -58,10 +58,10 @@ module.exports = {
                 player.playerStamina -= desiredMap.price;
                 return message.reply(`tente de réaliser la map ${desiredMap.icon} \`${desiredMap.name}\`! (\`-${desiredMap.price}\` ${stamina})`)
                     .then(() => {
+                        const isMapASuccess = mapManager.adventureSpecificMap(player, desiredMap, message);
+                        const experience = expManager.addExperience(player, isMapASuccess ? maxExperience*2 : maxExperience, message);
                         player.save()
                             .then(() => {
-                                const isMapASuccess = mapManager.adventureSpecificMap(player, desiredMap, message);
-                                const experience = expManager.addExperience(player, isMapASuccess ? maxExperience*2 : maxExperience, message);
                                 return message.reply(` a gagné \`+${experience}\` ${experienceFormat} en explorant la map ${desiredMap.icon} \`${desiredMap.name}\`.`);
                             })
                     });

--- a/commands/buy.js
+++ b/commands/buy.js
@@ -51,9 +51,9 @@ module.exports = {
                 const experience = expManager.addExperience(player, maxExperience, message);
                 player.playerInventory.push(desiredItem.name);
                 player.playerPurse -= desiredItem.price;
-                return message.reply(`a acheté un ${desiredItem.icon} \`${desiredItem.name}\` pour ${desiredItem.price} ${currency} (\`+${experience}\` ${experienceFormat}) !`)
+                player.save()
                     .then(() => {
-                        player.save()
+                        return message.reply(`a acheté un ${desiredItem.icon} \`${desiredItem.name}\` pour ${desiredItem.price} ${currency} (\`+${experience}\` ${experienceFormat}) !`);
                     });
             });
     }

--- a/commands/challenge.js
+++ b/commands/challenge.js
@@ -81,13 +81,14 @@ module.exports = {
                                     amount: price,
                                     createdAt: new Date()
                                 });
-                                newChallenge.save();
-                                const experience = expManager.addExperience(initiatorPlayer, maxExperience, message);
-
-                                return message.channel.send(`${challengeEmojis['initiator']}<@${newChallenge.initiatorId}> (\`+${experience}\` ${experienceFormat}) vient de défier ${challengeEmojis['opponent']} <@${newChallenge.opponentId}> ! Somme mise en jeu : \`${newChallenge.amount} ${currency}\` !`)
+                                newChallenge.save()
                                     .then(() => {
+                                        const experience = expManager.addExperience(initiatorPlayer, maxExperience, message);
                                         initiatorPlayer.initiatedChallenge++;
-                                        initiatorPlayer.save();
+                                        initiatorPlayer.save()
+                                            .then(() => {
+                                                return message.channel.send(`${challengeEmojis['initiator']}<@${newChallenge.initiatorId}> (\`+${experience}\` ${experienceFormat}) vient de défier ${challengeEmojis['opponent']} <@${newChallenge.opponentId}> ! Somme mise en jeu : \`${newChallenge.amount} ${currency}\` !`);
+                                            });
                                     });
                             });
                     })

--- a/commands/dependencies/_addExperience.js
+++ b/commands/dependencies/_addExperience.js
@@ -3,6 +3,7 @@ const levelManager = require('./_getPlayerLevel');
 const staminaManager = require('./_getPlayerStamina');
 
 module.exports = {
+    /* THIS FUNCTION DOESN'T SAVE THE PLAYER (anymore)! DON'T FORGET TO USE PLAYER.SAVE() IN THE CODE USING THIS FUNCTION!! */
     addExperience: (player, maxExperience, message) => {
         const oldExperience = player.playerExperience;
         const wonExperience = random.getRandomInt(maxExperience) +1;
@@ -10,13 +11,11 @@ module.exports = {
         player.playerExperience += wonExperience;
         if(levelManager.getPlayerLevel(player, oldExperience) < levelManager.getPlayerLevel(player, newExperience))
         {
-            message.channel.send(`🔼🆙 **﻿LEVEL UP** 🔼🆙﻿ <@${player.playerId}> est monté(e) de niveau ! Son endurance a été restaurée !`)
+            message.channel.send(`🔼🆙 **﻿LEVEL UP** 🔼🆙﻿ <@${player.playerId}> est monté(e) de niveau ! Son endurance a été restaurée !`);
             player.playerMaxStamina = staminaManager.getPlayerMaxStamina(player);
             player.playerStamina = player.playerMaxStamina;
-            player.save();
             return wonExperience
         }
-        player.save();
         return wonExperience
     }
 };

--- a/commands/dependencies/_getRandomBag.js
+++ b/commands/dependencies/_getRandomBag.js
@@ -113,34 +113,36 @@ module.exports = {
         }
         // Not a cursed bag, then set the quality of the regular bag...
         let quality;
-        const experience = expManager.addExperience(player, maxExperience, message);
         if(number <= maxCommon){ quality = "common"; }
         else if(number <= maxRare){ quality = "rare"; }
         else if(number <= maxEpic){ quality = "epic"; }
         else{ quality = "legendary"; }
-
-        return message.reply(`a trouvé un ${bagEmoji[quality]} sac ${bagFrName[quality]} ! ${bagSentence[quality]} (\`+${experience}\` ${experienceFormat})`)
-            .then(() =>{
-                message.channel.send(getMoneyBag(player, quality, message, player.playerCurses, buffManager.getPlayerTotalBuff(player)))
-                    .then(() => {
-                        if(extra.getExtraRuby()) {
-                            extra.rubyManager(player, message);
-                        }
-                    })
-                    .then(() => {
-                        if(buffManager.getABuff()) {
-                            buffManager.addABuff(player, message);
-                        }
-                    })
-                    .then(() => {
-                        // 1 chance in 10 not to trigger the CD
-                        if(random.getRandomInt(10) === 5)
-                        {
-                            cd.deleteTimer(player.playerId, 'loot');
-                            return message.channel.send(`Une distorsion de l'espace-temps a permis à <@${player.playerId}> de ne pas enclencher le CD de sa commande !loot !!`);
-                        }
+        const experience = expManager.addExperience(player, maxExperience, message);
+        player.save()
+            .then(() => {
+                return message.reply(`a trouvé un ${bagEmoji[quality]} sac ${bagFrName[quality]} ! ${bagSentence[quality]} (\`+${experience}\` ${experienceFormat})`)
+                    .then(() =>{
+                        message.reply(getMoneyBag(player, quality, message, player.playerCurses, buffManager.getPlayerTotalBuff(player)))
+                            .then(() => {
+                                if(extra.getExtraRuby()) {
+                                    extra.rubyManager(player, message);
+                                }
+                            })
+                            .then(() => {
+                                if(buffManager.getABuff()) {
+                                    buffManager.addABuff(player, message);
+                                }
+                            })
+                            .then(() => {
+                                // 1 chance in 10 not to trigger the CD
+                                if(random.getRandomInt(10) === 5)
+                                {
+                                    cd.deleteTimer(player.playerId, 'loot');
+                                    return message.channel.send(`Une distorsion de l'espace-temps a permis à <@${player.playerId}> de ne pas enclencher le CD de sa commande !loot !!`);
+                                }
+                            });
                     });
-            })
+            });
     },
     getMoneyBag,
     getCursedBag

--- a/commands/dependencies/items/bag.js
+++ b/commands/dependencies/items/bag.js
@@ -3,6 +3,6 @@ const buffManager = require('../_buffManager');
 
 module.exports = {
     useBagItem: (player, message, quality) => {
-        return message.channel.send(manager.getMoneyBag(player, quality, message, player.playerCurses, buffManager.getPlayerTotalBuff(player)));
+        return message.reply(manager.getMoneyBag(player, quality, message, player.playerCurses, buffManager.getPlayerTotalBuff(player)));
     }
 };

--- a/commands/improve.js
+++ b/commands/improve.js
@@ -71,19 +71,22 @@ module.exports = {
 
                 if(rng.getRandomInt(100) + 1 > chanceToSuccess[baseQuality]){
                     const experience = expManager.addExperience(player, maxExperience, message);
-                    return message.channel.send(`Malheureusement, l'amélioration de ${itemToImprove.icon} \`${itemToImprove.name}\` a échoué et l'objet a été perdu...`)
+                    player.playerInventory.splice(player.playerInventory.indexOf(itemToImprove.name), 1);
+                    player.save()
                         .then(() => {
-                            player.playerInventory.splice(player.playerInventory.indexOf(itemToImprove.name), 1);
-                            player.save();
-                        })
+                            return message.channel.send(`Malheureusement, l'amélioration de ${itemToImprove.icon} \`${itemToImprove.name}\` a échoué et l'objet a été perdu...`);
+                        });
                 }
+                player.playerInventory.splice(player.playerInventory.indexOf(itemToImprove.name), 1);
+                player.playerInventory.push(improvedItem.name);
+                player.playerMaterials.splice(player.playerMaterials.indexOf('stardust'), 1);
                 const experience = expManager.addExperience(player, maxExperience*multiplierIfItsASuccess, message);
-                return message.reply(`vient d'améliorer son ${itemToImprove.icon}\`${itemToImprove.name}\` en ${improvedItem.icon}\`${improvedItem.name}\` (\`+${experience}\` ${experienceFormat}) !`)
+                player.save()
                     .then(() => {
-                        player.playerInventory.splice(player.playerInventory.indexOf(itemToImprove.name), 1);
-                        player.playerInventory.push(improvedItem.name);
-                        player.playerMaterials.splice(player.playerMaterials.indexOf('stardust'), 1);
-                        player.save();
+                        return message.channel.send(`L'amélioration effectuée par <@${player.playerId}> est une réussite !!`)
+                            .then(() => {
+                                return message.reply(`vient d'améliorer son ${itemToImprove.icon}\`${itemToImprove.name}\` en ${improvedItem.icon}\`${improvedItem.name}\` (\`+${experience}\` ${experienceFormat}) !`);
+                            });
                     });
             });
     }

--- a/commands/useItem.js
+++ b/commands/useItem.js
@@ -51,15 +51,15 @@ module.exports = {
                                 itemToUse = item;
                             }
                         });
+                        player.playerInventory.splice(player.playerInventory.indexOf(itemToUse.name), 1);
                         const experience = expManager.addExperience(player, maxExperience, message);
-                        message.reply(`a utilisé un ${itemToUse.icon} \`${itemToUse.name}\` (\`+${experience}\` ${experienceFormat}) ! ${itemToUse.whenUsed}`)
+                        player.save()
                             .then(() => {
-                                player.playerInventory.splice(player.playerInventory.indexOf(itemToUse.name), 1);
-                                player.save()
+                                return message.reply(`a utilisé un ${itemToUse.icon} \`${itemToUse.name}\` (\`+${experience}\` ${experienceFormat}) ! ${itemToUse.whenUsed}`)
                                     .then(() => {
                                         use.useSpecificItem(player, itemToUse.name, message);
                                     });
-                            })
+                            });
                     }else {
                         cd.deleteTimer(message.author.id, this.name);
                         return message.reply("Tu ne possèdes pas cet objet !");


### PR DESCRIPTION
_addExperience no longer saves the player sheet. Useful to get more modularity with the codes depending on _addExperirence.

🟠 Editing : acceptChallenge.js ;
🟠 Editing : adventure.js ;
🟠 Editing : buy.js ;
🟠 Editing : challenge.js
🟠 Editing : _addExperience.js ;
🟠 Editing : _getRandomBag.js ;
🟠 Editing : bag.js ;
🟠 Editing : improve.js ;
🟠 Editing : useItem.js.